### PR TITLE
Edge shift

### DIFF
--- a/QB3.md
+++ b/QB3.md
@@ -196,14 +196,6 @@ rung for the CF group or when the CF-2 rung is much smaller than the group rung
 encoded with its own rung, CF is always in the top rung, so we can save one or 
 more bits by enconding CF at the next lower rung.
 
-### Quantized encoding
-
-This encoding is used to improve compression, by storing the values in a quantized form. The quantization is done by
-dividing the values by a quantization factor, then rounding the result to the nearest integer. The quantization factor
-is itself an integer. The quantized values are then encoded using the QB3 encoding. The quantization factor is stored
-in a QB3 chunk. On decoding, the values in the QB3 stream are multiplied by the quantization factor to restore the range
-of the original values. Note that the range of the output values may be different from the input values due to rounding.
-
 ## QB3 image encoding
 
 The QB3 image encoding adds a few metadata fields to the QB3 block stream, making it possible to decode
@@ -241,4 +233,13 @@ The "QV" chunk is not present when the quanta value is 1.
 The "DT" chunk signature is used to signify the end of the chunks, and it is followed by QB3 encoded stream. 
 Note that the "DT" chunk does not have a size field. All the data after the "DT" signature is part of the QB3 encoded stream. If the decoder 
 is not provided with sufficient data to fully decode the image, it will return an error.
+
+### Quantized image encoding
+
+This encoding is used to improve compression by storing the values in a pre-quantized form. The quantization is done by
+dividing the input values by a quantization factor, then rounding the result to the nearest integer. The quantization factor
+is itself an integer. The quantization factor is stored in a QB3 image chunk. The quantized values are then encoded using 
+QB3 encoding. On decoding, the values decoded from the QB3 stream are multiplied by the quantization factor to restore the range
+of the original values. Note that the range of the output values may be different from the input values due to rounding.
+While the QB3 stream encoding is lossless, the quantization is lossy.
 

--- a/QB3.md
+++ b/QB3.md
@@ -83,6 +83,18 @@ If the number of the short values in a group is larger than the number of long v
 whole group will be less than if the values in the group are stored without this encoding. Since this condition is 
 very frequently true, the variable size encoding results in compression.
 
+### Edge handling
+
+Since QB3 is a block based encoding, the last block in a row or column may not be a full 4x4 block. Yet in practice this
+would be a serious limitation. QB3 solves this by shifting the begining of the last block in a row or column to the left or up,
+so that the last block is always a full 4x4 block. This means that the last block may duplicate some values from the previous block.
+While this method results in sub-optimal compression, it is simple and fast. The worst case is when both the width and the height
+of the image is of the form 4*N+1, where N is an integer. In this case, the amount of redundant pixels expressed in percentage is
+`300 * (W + H) / WH` or `600 / S` for a square image. This is a reasonable tradeoff for the simplicity of the algorithm. For 
+optimal results, the image should be a multiple of 4 in both dimensions, or padded externally to such a size. When the image 
+is padded, duplicating the values in the last column and/or row is a good choice, it will affect the compression ratio less than
+padding with zero.
+
 ### QB3 Bitstream
 
 The QB3 bitstream is a concatenation of encoded groups, each encoded individually at a specific rung. In the case of multi 

--- a/QB3lib/QB3decode.h
+++ b/QB3lib/QB3decode.h
@@ -204,8 +204,14 @@ static bool decode(uint8_t *src, size_t len, T* image,
     iBits s(src, len);
 
     bool failed(false);
-    for (size_t y = 0; (y + B) <= ysize; y += B) {
-        for (size_t x = 0; (x + B) <= xsize; x += B) {
+    for (size_t y = 0; y < ysize; y += B) {
+        // If the last row is partial, roll it up
+        if (y + B > ysize)
+            y = ysize - B;
+        for (size_t x = 0; x < xsize; x += B) {
+            // If the last column is partial, move it left
+            if (x + B > xsize)
+                x = xsize - B;
             for (int c = 0; c < bands; c++) {
                 uint64_t cs(0), abits(1), acc(s.peek());
                 if (acc & 1) { // Rung change

--- a/QB3lib/QB3encode.h
+++ b/QB3lib/QB3encode.h
@@ -312,7 +312,13 @@ static int encode_fast(const T* image, oBits& s, encs &info)
         offsets[i] = (xsize * ylut[i] + xlut[i]) * bands;
     T group[B2];
     for (size_t y = 0; y < ysize; y += B) {
+        // If the last row is partial, roll it up
+        if (y + B > ysize)
+            y = ysize - B;
         for (size_t x = 0; x < xsize; x += B) {
+            // If the last column is partial, move it left
+            if (x + B > xsize)
+                x = xsize - B;                
             const size_t loc = (y * xsize + x) * bands; // Top-left pixel address
             for (size_t c = 0; c < bands; c++) { // blocks are band interleaved
                 T maxval(0); // Maximum mag-sign value within this group
@@ -380,7 +386,13 @@ static int encode_best(const T *image, oBits& s, encs &info)
     for (size_t i = 0; i < B2; i++)
         offsets[i] = (xsize * ylut[i] + xlut[i]) * bands;
     for (size_t y = 0; y < ysize; y += B) {
+        // If the last row is partial, roll it up
+        if (y + B > ysize)
+            y = ysize - B;
         for (size_t x = 0; x < xsize; x += B) {
+            // If the last column is partial, move it left
+            if (x + B > xsize)
+                x = xsize - B;
             size_t loc = (y * xsize + x) * bands; // Top-left pixel address
             for (size_t c = 0; c < bands; c++) { // blocks are always band interleaved
                 T maxval(0); // Maximum mag-sign value within this group

--- a/README.md
+++ b/README.md
@@ -18,7 +18,11 @@ Only 64bit builds should be used, since the implementation makes heavy use of 64
 bit values.
 
 # Use
-The easiest way to try it out is to build [GDAL](https://github.com/OSGeo/GDAL) and
+
+[cqb3](cqb3.md) is a utility conversion program that can convert PNG and JPEG images to and
+from QB3, for 8 and 16 bit images.  
+
+Another option is to build [GDAL](https://github.com/OSGeo/GDAL) and
 enable QB3 in MRF.  
 [QB3.h](QB3lib/QB3.h) contains the public C API.
 Opaque encoder and decoder control structures have to be created, then options and 

--- a/cqb3.cpp
+++ b/cqb3.cpp
@@ -53,6 +53,7 @@ int Usage(const options &opt) {
         << "Options:\n"
         << "\t-v : verbose\n"
         << "\t-b : best compression\n"
+        << "\t-m <b,b,b> : band mapping for compression\n"
         << "\t-d : decode QB3\n"
         ;    
     return 1;
@@ -277,10 +278,10 @@ int encode_main(options& opts) {
         cerr << "Image " << raster.size.x << "x" << raster.size.y << "@" 
             << raster.size.c << "\nSize " << fsize
             << ((raster.dt != ICDT_Byte) ? " 16bit\n" : "\n");
-    if (raster.size.x % 4 or raster.size.y % 4) {
-        cerr << "QB3 requires input size to be a multiple of 4\n";
-        return 2;
-    }
+    //if (raster.size.x % 4 or raster.size.y % 4) {
+    //    cerr << "QB3 requires input size to be a multiple of 4\n";
+    //    return 2;
+    //}
     codec_params params(raster);
 
     if (raster.dt != ICDT_Byte && raster.dt != ICDT_UInt16 && raster.dt != ICDT_Short) {

--- a/cqb3.md
+++ b/cqb3.md
@@ -1,0 +1,52 @@
+
+# cqb3 Manual
+
+cqb3 - convert an image file to and from QB3 format
+
+Synopsis
+
+cqb3 [ options ] filename [ output filename ]
+
+Description
+
+cqb3 reads the named input file and produces a QB3 file with the same name as the input filename and the **.QB3** extension. 
+QB3 is a very efficient and very fast lossless image compression that supports 8, 16, 32 and 64 integer values.  
+The cqb3 utility uses libicd for reading the input, which at the current time can read PNG and JFIF formatted images, with 8 and 16 bits per value. 
+It can also decode a QB3 formatted input file and write it as a PNG file.
+
+Options
+
+Each option has to be preceeded by a - (dash) and separated by white spaces from any other option or argument.
+
+-v
+Verbose operation. Basic information about the input and output, compression ratios compared with raw input, as well as timing information 
+is printed to standard error. Without this option only errors are printed.
+
+-d
+Decompress. Reads a QB3 formatted file and writes a PNG.
+
+-b
+Best. Turns on the **best** QB3 compression mode, which is slower but can produce better compression, especially for larger integer types.
+
+-m <a,b,c,...>
+band Mapping control. For images with more than one channel, QB3 can apply a band decorrelation filter which improves the compression. It does this
+by subtracting one band from another. On decompression the effect of the filter is removed and the output image is identical to the input.
+The default band mapping for color images with three or four bands assumes that the first three bands are the red, green and blue respectively and 
+converts the input image to red - green, green, blue - green. The fourth band, if present, is left as is. The band mapping control allows this
+default filter to be turned off, or the definition of a custom band mapping. Without a numerical argument, the band decorrelation filter is not 
+applied (identity band mapping). The optional argument consist of a comma separated numerical list of band indexes which are to be subtracted from the
+input bands. Band indexes are zero based. For the purpose of the band mapping, a band can be either a core band (unmodified) or derived (modified).
+Only core bands can be subtracted from other bands. To mark a band as core, use it's band index as the argument in the band position in the band mapping.
+Any other valid band index means that the respective core band will be subtracted from the respective band.
+For example, the default RGB filter R-G,G,B-G is equivalent to the -m 1,1,1 argument, meaning that band 1 (green) is a core band (position 1 is 1), 
+while band 1 (green) is to be subtracted from the 0 (red) and 2 (blue) bands. If the number of arguments is shorter than the number of bands in the
+input, the unspecified band mappings are left unmodified (core). Following the same logic, the -m option with no parameters is equivalent to the
+identity mapping, -m 0,1,2,... For RGBI (infrared) imagery, the 1,1,1,1 might be better than the default, which leaves the last band as is.
+The QB3 compressor will adjust the band input mapping if the values are not valid, a warning will be printed by cqb3 when this happens.
+
+-t
+Trim. QB3 compression operates on 4x4 pixel blocks. When the input image size is not a multiple of 4x4, libQB3 will internally encode a few lines
+and columns more than once. This may result in an output size that is slightly larger. When the trim option is present as a command line argument,
+the input image will be trimmed to a multiple of 4x4 pixels before compression to QB3. The output QB3 raster size will reflect this trimmed size.
+1, 2 or three lines and/or columns will be trimmed, in the last, then first, then last again order, as necessary to make the respective dimension 
+a multiple of 4.

--- a/cqb3/cqb3.vcxproj
+++ b/cqb3/cqb3.vcxproj
@@ -99,6 +99,9 @@
   <ItemGroup>
     <ClCompile Include="..\cqb3.cpp" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="..\cqb3.md" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>

--- a/cqb3/cqb3.vcxproj.filters
+++ b/cqb3/cqb3.vcxproj.filters
@@ -19,4 +19,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="..\cqb3.md">
+      <Filter>Resource Files</Filter>
+    </None>
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Allows for size that are not a multiple of 4 (min 4, max 65536)
It does it by shifting the edges in so that the last micro-block ends at the last pixel. This is a simple and fast workaround, although it leads to a larger output than possible.