### PR TITLE
Version 1

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Auto detect text files and perform LF normalization
+* text=lf

--- a/MSVC/QB3.vcxproj
+++ b/MSVC/QB3.vcxproj
@@ -69,7 +69,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>libicd.lib;libQB3.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>libicdd.lib;libQB3.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
       <Command>copy /y $(TargetPath) $(Prefix)bin</Command>

--- a/MSVC/QB3lib.vcxproj
+++ b/MSVC/QB3lib.vcxproj
@@ -82,7 +82,7 @@
     <PostBuildEvent>
       <Command>copy /y $(TargetPath) $(Prefix)bin
 copy /y $(TargetDir)$(TargetName).lib $(Prefix)lib
-copy /y $(ProjectDir)QB3.h $(Prefix)include</Command>
+copy /y $(ProjectDir)..\QB3lib\QB3.h $(Prefix)include</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">

--- a/MSVC/QB3lib.vcxproj
+++ b/MSVC/QB3lib.vcxproj
@@ -87,7 +87,7 @@ copy /y $(ProjectDir)..\QB3lib\QB3.h $(Prefix)include</Command>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>

--- a/QB3lib/CMakeLists.txt
+++ b/QB3lib/CMakeLists.txt
@@ -9,7 +9,7 @@ endif(NOT CMAKE_BUILD_TYPE)
 
 project(libQB3 
     DESCRIPTION "QB3 Raster Compression Library"
-    VERSION 0.9.1
+    VERSION 1.0.0
     LANGUAGES CXX
 )
 

--- a/QB3lib/QB3.h
+++ b/QB3lib/QB3.h
@@ -70,6 +70,9 @@ DLLEXPORT encsp qb3_create_encoder(size_t width, size_t height, size_t bands, qb
 // Call when done with the encoder
 DLLEXPORT void qb3_destroy_encoder(encsp p);
 
+// Reset state, allowing encoder to be reused
+DLLEXPORT void qb3_reset_encoder(encsp p);
+
 // Change the default core band mapping.
 // The default assumes bands are independent, except for 3 or 4 bands
 // when RGB(A) is assumed and R-G and B-G is used

--- a/QB3lib/QB3.h
+++ b/QB3lib/QB3.h
@@ -41,8 +41,16 @@ typedef struct decs * decsp; // decoder
 
 // Types
 enum qb3_dtype { QB3_U8 = 0, QB3_I8, QB3_U16, QB3_I16, QB3_U32, QB3_I32, QB3_U64, QB3_I64 };
-// Encode mode
-enum qb3_mode { QB3M_DEFAULT = 0, QB3M_BASE = 0, QB3M_BEST };
+
+// Encode mode, default is QB3M_BASE, pure QB3 encoding. Fastest
+// QB3M_BEST is the best compression, may change
+enum qb3_mode { 
+    QB3M_DEFAULT = 0, 
+    QB3M_BASE = 0, 
+    QB3M_CF = 1, // With common factor
+    QB3M_RLE = 2, // BASE + RLE
+    QB3M_CF_RLE = 3, // BASE + CF + RLE
+    QB3M_BEST = 3}; // Best compression, one of the above
 
 // Errors
 enum qb3_error {
@@ -79,8 +87,8 @@ DLLEXPORT size_t qb3_max_encoded_size(const encsp p);
 // If mode value is out of range, it returns the previous mode value of p
 DLLEXPORT qb3_mode qb3_set_encoder_mode(encsp p, qb3_mode mode);
 
-// Generate raw qb3 stream, no headers
-DLLEXPORT void qb3_set_encoder_raw(encsp p);
+//// Generate raw qb3 stream, no headers
+//DLLEXPORT void qb3_set_encoder_raw(encsp p);
 
 // Encode the source into destination buffer, which should be at least qb3_max_encoded_size
 // Source organization is expected to be y major, then x, then band (interleaved)
@@ -96,11 +104,11 @@ DLLEXPORT int qb3_get_encoder_state(encsp p);
 // To be used by raw and formatted QB3 streams
 DLLEXPORT void qb3_destroy_decoder(decsp p);
 
-// Raw functions
-DLLEXPORT decsp qb3_create_raw_decoder(size_t width, size_t height, size_t bands, qb3_dtype dt);
-
-DLLEXPORT size_t qb3_decode(decsp p, void* source, size_t src_sz, void* destination);
-
+//// Raw functions
+//DLLEXPORT decsp qb3_create_raw_decoder(size_t width, size_t height, size_t bands, qb3_dtype dt);
+//
+//DLLEXPORT size_t qb3_decode(decsp p, void* source, size_t src_sz, void* destination);
+//
 DLLEXPORT size_t qb3_decoded_size(const decsp p);
 
 DLLEXPORT qb3_dtype qb3_get_type(const decsp p);

--- a/QB3lib/QB3.h
+++ b/QB3lib/QB3.h
@@ -51,7 +51,8 @@ enum qb3_mode {
     QB3M_RLE = 2, // BASE + RLE
     QB3M_CF_RLE = 3, // BASE + CF + RLE
     QB3M_BEST = 3,
-    QB3M_STORED = 255 // Raw bypass
+    QB3M_STORED = 255, // Raw bypass
+    QB3M_INVALID = -1 // Invalid mode
 }; // Best compression, one of the above
 
 // Errors
@@ -103,20 +104,6 @@ DLLEXPORT int qb3_get_encoder_state(encsp p);
 
 // In QB3decode.cpp
 
-// To be used by raw and formatted QB3 streams
-DLLEXPORT void qb3_destroy_decoder(decsp p);
-
-//// Raw functions
-//DLLEXPORT decsp qb3_create_raw_decoder(size_t width, size_t height, size_t bands, qb3_dtype dt);
-//
-//DLLEXPORT size_t qb3_decode(decsp p, void* source, size_t src_sz, void* destination);
-//
-DLLEXPORT size_t qb3_decoded_size(const decsp p);
-
-DLLEXPORT qb3_dtype qb3_get_type(const decsp p);
-
-// Formatted stream decode functions
-
 // Starts reading a formatted QB3 source. Reads the main header, which only contains the output size information
 // returns nullptr if it fails, usually because the source is not in the correct format
 // If successful, size containts 3 values, x size, y size and number of bands
@@ -127,6 +114,23 @@ DLLEXPORT bool qb3_read_info(decsp p);
 
 // Call after qb3_read_info, reads all the data, returns bytes read
 DLLEXPORT size_t qb3_read_data(decsp p, void* destination);
+
+DLLEXPORT void qb3_destroy_decoder(decsp p);
+
+DLLEXPORT size_t qb3_decoded_size(const decsp p);
+
+DLLEXPORT qb3_dtype qb3_get_type(const decsp p);
+
+// Query settings, valid after qb3_read_info
+
+// Encoding mode used, returns QB3M_INVALID if failed
+DLLEXPORT qb3_mode qb3_get_mode(const decsp p);
+
+// Returns the number of quantization bits used, returns 0 if failed
+DLLEXPORT size_t qb3_get_quanta(const decsp p);
+
+// Sets the cband array and returns true if successful
+DLLEXPORT bool qb3_get_coreband(const decsp p, size_t *cband);
 
 #if defined(__cplusplus)
 }

--- a/QB3lib/QB3.h
+++ b/QB3lib/QB3.h
@@ -50,7 +50,9 @@ enum qb3_mode {
     QB3M_CF = 1, // With common factor
     QB3M_RLE = 2, // BASE + RLE
     QB3M_CF_RLE = 3, // BASE + CF + RLE
-    QB3M_BEST = 3}; // Best compression, one of the above
+    QB3M_BEST = 3,
+    QB3M_STORED = 255 // Raw bypass
+}; // Best compression, one of the above
 
 // Errors
 enum qb3_error {

--- a/QB3lib/QB3.h
+++ b/QB3lib/QB3.h
@@ -1,4 +1,6 @@
 /*
+Content: Public API for QB3 library
+
 Copyright 2021-2022 Esri
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -9,8 +11,6 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-
-Content: Forward definition headers, to be used when linking with QB3 library
 
 Contributors:  Lucian Plesea
 */

--- a/QB3lib/QB3common.h
+++ b/QB3lib/QB3common.h
@@ -40,7 +40,7 @@ constexpr size_t B2(B * B);
 #endif
 
 #if defined(_WIN32)
-// rank of top set bit, result is undefined for val == 0
+// blog2 of val, result is undefined for val == 0
 static size_t topbit(uint64_t val) {
     return 63 - __lzcnt64(val);
 }
@@ -59,11 +59,14 @@ static size_t setbits16(uint64_t val) {
 }
 
 #else // no builtins, portable C
-static size_t topbit(uint64_t val) {
-    unsigned r = 0;
-    while (val >>= 1)
-        r++;
-    return r;
+// blog2 of val, result is undefined for val == 0
+static size_t topbit(uint64_t v) {
+    size_t r, t;
+    r = size_t(0 != (v >> 32)) << 5; v >>= r;
+    t = size_t(0 != (v >> 16)) << 4; v >>= t; r |= t;
+    t = size_t(0 != (v >> 8)) << 3;  v >>= t; r |= t;
+    t = size_t(0 != (v >> 4)) << 2;  v >>= t; r |= t;
+    return r + ((0xffffaa50ull >> (v << 1)) & 0x3);
 }
 
 // My own portable byte bitcount

--- a/QB3lib/QB3common.h
+++ b/QB3lib/QB3common.h
@@ -90,7 +90,7 @@ struct encs {
     size_t nbands;
     size_t quanta;
 
-    // Persistent stage by band
+    // Persistent state by band
     band_state band[QB3_MAXBANDS];
     // band which will be subtracted, by band
     size_t cband[QB3_MAXBANDS];

--- a/QB3lib/QB3common.h
+++ b/QB3lib/QB3common.h
@@ -80,22 +80,26 @@ static size_t setbits16(uint64_t val) {
 
 #endif
 
+struct band_state {
+    size_t prev, runbits;
+};
+
 // Encoder control structure
 struct encs {
     size_t xsize;
     size_t ysize;
     size_t nbands;
     size_t quanta;
+
+    // Persistent stage by band
+    band_state band[QB3_MAXBANDS];
     // band which will be subtracted, by band
     size_t cband[QB3_MAXBANDS];
 
-    // end state
-    size_t prev[QB3_MAXBANDS];
-    size_t runbits[QB3_MAXBANDS];
+    int error; // Holds the code for error, 0 if everything is fine
 
     qb3_mode mode;
     qb3_dtype type;
-    int error; // Holds the code for error, 0 if everything is fine
     bool away; // Round up instead of down when quantizing
 };
 
@@ -105,12 +109,13 @@ struct decs {
     size_t ysize;
     size_t nbands;
     size_t quanta;
-    // band which will be subtracted, by band
-    size_t cband[QB3_MAXBANDS];
+    int error;
+    int stage;
+
+    // band which will be added, by band
+    uint8_t cband[QB3_MAXBANDS];
     qb3_mode mode;
     qb3_dtype type;
-    int error;
-    int state;
 
     // Input buffer
     uint8_t* s_in;

--- a/QB3lib/QB3common.h
+++ b/QB3lib/QB3common.h
@@ -94,7 +94,6 @@ struct encs {
     qb3_dtype type;
     int error; // Holds the code for error, 0 if everything is fine
     bool away; // Round up instead of down when quantizing
-    bool raw;  // Write QB3 raw stream
 };
 
 // Decoder control structure
@@ -109,7 +108,6 @@ struct decs {
     qb3_dtype type;
     int error;
     int state;
-    bool raw;
 
     // Input buffer
     uint8_t* s_in;

--- a/QB3lib/QB3common.h
+++ b/QB3lib/QB3common.h
@@ -27,7 +27,7 @@ Contributors:  Lucian Plesea
 #endif
 
 // Tables have 12bits of data, top 4 bits are size
-#define TBLMASK 0xfffull
+constexpr auto TBLMASK(0xfffull);
 
 // Block is 4x4 pixels
 constexpr size_t B(4);
@@ -80,7 +80,7 @@ static size_t setbits16(uint64_t val) {
 #endif
 
 struct band_state {
-    size_t prev, runbits;
+    size_t prev, runbits, cf;
 };
 
 // Encoder control structure
@@ -121,15 +121,6 @@ struct decs {
     size_t s_size;
 };
 
-// Main header
-// 4 sig
-// 2 xsize
-// 2 ysize
-// 1 nbands
-// 1 data type
-// 1 mode
-constexpr size_t QB3_HDRSZ = 4 + 2 + 2 + 1 + 1 + 1;
-
 // in decode.cpp
 extern const int typesizes[8];
 
@@ -146,11 +137,9 @@ static T mags(T v) {
 
 // Undo mag-sign without conditionals, as fast as C can make it
 template<typename T>
-static T smag(T v) { return (v >> 1) ^ (~T(0) * (v & 1)); }
-
-// Absolute from mag-sign
-template<typename T>
-static T magsabs(T v) { return (v >> 1) + (v & 1); }
+static T smag(T v) {
+    return (v >> 1) ^ (~T(0) * (v & 1));
+}
 
 // If the rung bits of the input values match 1*0*, returns the index of first 0, otherwise B2 + 1
 template<typename T>

--- a/QB3lib/QB3common.h
+++ b/QB3lib/QB3common.h
@@ -1,4 +1,6 @@
 /*
+Content: QB3 parts used by both the encoder and the decoder
+
 Copyright 2020-2023 Esri
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -11,9 +13,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 Contributors:  Lucian Plesea
-
-Content: QB3 parts used by both the encoder and the decoder
-
 */
 
 #pragma once
@@ -147,15 +146,11 @@ static T mags(T v) {
 
 // Undo mag-sign without conditionals, as fast as C can make it
 template<typename T>
-static T smag(T v) {
-    return (v >> 1) ^ (~T(0) * (v & 1));
-}
+static T smag(T v) { return (v >> 1) ^ (~T(0) * (v & 1)); }
 
 // Absolute from mag-sign
 template<typename T>
-static T magsabs(T val) {
-    return (val >> 1) + (val & 1);
-}
+static T magsabs(T v) { return (v >> 1) + (v & 1); }
 
 // If the rung bits of the input values match 1*0*, returns the index of first 0, otherwise B2 + 1
 template<typename T>

--- a/QB3lib/QB3decode.cpp
+++ b/QB3lib/QB3decode.cpp
@@ -21,6 +21,15 @@ Contributors:  Lucian Plesea
 #include <cstring>
 #include <vector>
 
+// Main header
+// 4 sig
+// 2 xsize
+// 2 ysize
+// 1 nbands
+// 1 data type
+// 1 mode
+constexpr size_t QB3_HDRSZ = 4 + 2 + 2 + 1 + 1 + 1;
+
 void qb3_destroy_decoder(decsp p) {
     delete p;
 }

--- a/QB3lib/QB3decode.cpp
+++ b/QB3lib/QB3decode.cpp
@@ -33,6 +33,26 @@ qb3_dtype qb3_get_type(const decsp p) {
     return p->type;
 }
 
+qb3_mode qb3_get_mode(const decsp p) {
+    if (p->stage != 2)
+        return qb3_mode::QB3M_INVALID;
+    return p->mode;
+}
+
+uint64_t qb3_get_quanta(const decsp p) {
+    if (p->stage != 2)
+        return 0; // Error
+    return p->quanta;
+}
+
+bool qb3_get_coreband(const decsp p, size_t *coreband) {
+    if (p->stage != 2)
+        return false; // Error
+    for (int c = 0; c < p->nbands; c++)
+        coreband[c] = p->cband[c];
+    return true;
+}
+
 // Integer multiply but don't overflow, at least on the positive side
 template<typename T>
 static void dequantize(T* d, const decsp p) {

--- a/QB3lib/QB3decode.cpp
+++ b/QB3lib/QB3decode.cpp
@@ -1,4 +1,6 @@
 /*
+Content: C API QB3 decoding
+
 Copyright 2021-2023 Esri
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -9,8 +11,6 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-
-Content: C API QB3 decoding
 
 Contributors:  Lucian Plesea
 */

--- a/QB3lib/QB3decode.cpp
+++ b/QB3lib/QB3decode.cpp
@@ -111,7 +111,7 @@ decsp qb3_read_start(void* source, size_t source_size, size_t *image_size) {
     val >>= 8; // 40 bits left
     // Also check that the next 2 bytes are a signature
     if (p->nbands > QB3_MAXBANDS 
-        || p->mode > qb3_mode::QB3M_BEST
+        || (p->mode > qb3_mode::QB3M_BEST && p->mode != qb3_mode::QB3M_STORED)
         || 0 != (val & 0x8080) 
         || p->type > qb3_dtype::QB3_I64) {
         delete p;

--- a/QB3lib/QB3decode.h
+++ b/QB3lib/QB3decode.h
@@ -17,7 +17,6 @@ Contributors:  Lucian Plesea
 
 #pragma once
 #include "QB3common.h"
-#include <iostream>
 
 namespace QB3 {
 // Decoding tables, twice as large as the encoding ones
@@ -335,11 +334,6 @@ static bool decode(uint8_t *src, size_t len, T* image,
             if (x + B > xsize)
                 x = xsize - B;
             for (int c = 0; c < bands; c++) {
-                if (y == 0 && x < 30) {
-                    static auto diff = s.position();
-                    std::cout << y << " " << x << " " << c << " " << s.position() - diff << std::endl;
-                }
-
                 failed |= s.empty();
                 uint64_t cs(0), abits(1), acc(s.peek());
                 if (acc & 1) { // Rung change
@@ -414,7 +408,7 @@ static bool decode(uint8_t *src, size_t len, T* image,
                     }
                     else { // IDX encoding goes here
                         cs = dsw[acc & LONG_MASK]; // rung, no flag
-                        auto rung = (runbits[c] + cs) & NORM_MASK;
+                        rung = (runbits[c] + cs) & NORM_MASK;
                         runbits[c] = rung;
                         acc >>= (cs >> 12) - 1; // No flag
                         abits += (cs >> 12) - 1;

--- a/QB3lib/QB3decode.h
+++ b/QB3lib/QB3decode.h
@@ -372,7 +372,7 @@ static bool decode(uint8_t *src, size_t len, T* image,
                         }
                         // when rung != cfrung, cfrung is encoded one rung below and the rung bit is set
                         auto p = qb3dsztbl(acc, cfrung - T(read_cfrung));
-                        T cf = static_cast<T>(p.second + 2 + (T(read_cfrung) << cfrung));
+                        T cf = static_cast<T>(p.second + 2 + (uint64_t(read_cfrung) << cfrung));
                         s.advance(abits + p.first);
                         acc = s.peek();
                         if (rung > 0) {

--- a/QB3lib/QB3decode.h
+++ b/QB3lib/QB3decode.h
@@ -17,6 +17,7 @@ Contributors:  Lucian Plesea
 
 #pragma once
 #include "QB3common.h"
+#include <iostream>
 
 namespace QB3 {
 // Decoding tables, twice as large as the encoding ones
@@ -334,6 +335,11 @@ static bool decode(uint8_t *src, size_t len, T* image,
             if (x + B > xsize)
                 x = xsize - B;
             for (int c = 0; c < bands; c++) {
+                if (y == 0 && x < 30) {
+                    static auto diff = s.position();
+                    std::cout << y << " " << x << " " << c << " " << s.position() - diff << std::endl;
+                }
+
                 failed |= s.empty();
                 uint64_t cs(0), abits(1), acc(s.peek());
                 if (acc & 1) { // Rung change
@@ -426,7 +432,7 @@ static bool decode(uint8_t *src, size_t len, T* image,
                         }
                         s.advance(abits);
                         T values[B2] = {};
-                        for (size_t i = 0; i < maxval; i++) {
+                        for (size_t i = 0; i <= maxval; i++) {
                             acc = s.peek();
                             auto v = qb3dsztbl(acc, rung);
                             values[i] = T(v.second);

--- a/QB3lib/QB3decode.h
+++ b/QB3lib/QB3decode.h
@@ -1,4 +1,6 @@
 /*
+Content: QB3 decoding
+
 Copyright 2020-2023 Esri
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -9,8 +11,6 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-
-Content: Decoder for QB3 compression
 
 Contributors:  Lucian Plesea
 */

--- a/QB3lib/QB3decode.h
+++ b/QB3lib/QB3decode.h
@@ -299,11 +299,11 @@ static bool gdecode(iBits &s, size_t rung, T * group, uint64_t acc, size_t abits
     return true;
 }
 
+// Absolute from mag-sign
+template<typename T> static T magsabs(T v) { return (v >> 1) + (v & 1); }
+
 // integer multiply val(in magsign) by cf(normal, positive)
-template<typename T>
-static T magsmul(T val, T cf) {
-    return magsabs(val) * (cf << 1) - (val & 1);
-}
+template<typename T> static T magsmul(T val, T cf) { return magsabs(val) * (cf << 1) - (val & 1); }
 
 // reports most but not all errors, for example if the input stream is too short for the last block
 template<typename T>
@@ -315,13 +315,13 @@ static bool decode(uint8_t *src, size_t len, T* image,
     const uint8_t xlut[16] = { 0, 1, 0, 1, 2, 3, 2, 3, 0, 1, 0, 1, 2, 3, 2, 3 };
     const uint8_t ylut[16] = { 0, 0, 1, 1, 0, 0, 1, 1, 2, 2, 3, 3, 2, 2, 3, 3 };
     constexpr size_t UBITS(sizeof(T) == 1 ? 3 : sizeof(T) == 2 ? 4 : sizeof(T) == 4 ? 5 : 6);
-    constexpr auto LONG_MASK((1ull << (UBITS + 1)) - 1);
-    constexpr auto NORM_MASK(LONG_MASK >> 1);
-    T prev[QB3_MAXBANDS] = {}, group[B2] = {};
+    constexpr auto NORM_MASK((1ull << UBITS) - 1); // UBITS set
+    constexpr auto LONG_MASK(NORM_MASK * 2 + 1); // UBITS + 1 set
+    T prev[QB3_MAXBANDS] = {}, pcf[QB3_MAXBANDS] = {}, group[B2] = {};
     size_t runbits[QB3_MAXBANDS] = {}, offset[B2] = {};
+    const uint16_t* dsw(sizeof(T) == 1 ? DSW[3] : sizeof(T) == 2 ? DSW[4] : sizeof(T) == 4 ? DSW[5] : DSW[6]);
     for (size_t i = 0; i < B2; i++)
         offset[i] = (xsize * ylut[i] + xlut[i]) * bands;
-    const uint16_t* dsw(sizeof(T) == 1 ? DSW[3] : sizeof(T) == 2 ? DSW[4] : sizeof(T) == 4 ? DSW[5] : DSW[6]);
     iBits s(src, len);
 
     bool failed(false);
@@ -334,75 +334,87 @@ static bool decode(uint8_t *src, size_t len, T* image,
             if (x + B > xsize)
                 x = xsize - B;
             for (int c = 0; c < bands; c++) {
-                failed |= s.empty(); // Stream can't be empty here
+                failed |= s.empty();
                 uint64_t cs(0), abits(1), acc(s.peek());
                 if (acc & 1) { // Rung change
                     cs = dsw[(acc >> 1) & LONG_MASK];
                     abits = cs >> 12;
                 }
                 acc >>= abits;
-                
+
                 if (0 == cs || 0 != (cs & TBLMASK)) { // Normal decoding, not a signal
                     // abits is never > 8, so it's safe to call gdecode
                     auto rung = (runbits[c] + cs) & NORM_MASK;
                     failed |= !gdecode(s, rung, group, acc, abits);
                     runbits[c] = rung;
                 }
-                else { // signal, cf decodind
-                    bool read_cfrung = !(acc & 1); // No cfrung flag
-                    cs = dsw[(acc >> 1) & LONG_MASK];
+                else {
+                    cs = dsw[acc & LONG_MASK]; // rung, no flag
                     auto rung = (runbits[c] + cs) & NORM_MASK;
+                    failed |= (rung == NORM_MASK); // Not possible in CF encoding
                     auto cfrung(rung);
-                    failed |= (rung == 63); // can't be 63 since CF encoding looses at least one rung
-                    abits += cs >> 12;
-                    acc >>= cs >> 12;
-                    if (read_cfrung) { // read cfrung separately, no code switch flag
-                        cs = dsw[acc & LONG_MASK];
-                        abits += (cs >> 12) - 1;
-                        acc >>= (cs >> 12) - 1;
-                        cfrung = (rung + cs) & NORM_MASK;
-                        failed |= (rung == cfrung);
-                    }
-
-                    if (rung | cfrung) { // 0 < cfrung < 63
+                    acc >>= (cs >> 12) - 1;
+                    abits += (cs >> 12) - 1;
+                    T cf = pcf[c];
+                    size_t read_cfrung(0);
+                    if (acc & 1) { // different cf
+                        acc >>= 1;
+                        read_cfrung = acc & 1;
+                        abits += 2;
+                        acc >>= 1;
+                        if (0 != read_cfrung) {
+                            cs = dsw[acc & LONG_MASK];
+                            cfrung = (rung + cs) & NORM_MASK;
+                            failed |= (cfrung == rung);
+                            acc >>= (cs >> 12) - 1;
+                            abits += (cs >> 12) - 1;
+                        }
                         if (sizeof(T) == 8 && (cfrung + abits) > 62) {
                             s.advance(abits);
                             acc = s.peek();
                             abits = 0;
                         }
-                        // when rung != cfrung, cfrung is encoded one rung below and the rung bit is set
-                        auto p = qb3dsztbl(acc, cfrung - T(read_cfrung));
-                        T cf = static_cast<T>(p.second + 2 + (uint64_t(read_cfrung) << cfrung));
-                        s.advance(abits + p.first);
-                        acc = s.peek();
-                        if (rung > 0) {
+                        auto p = qb3dsztbl(acc, cfrung - read_cfrung);
+                        cf = static_cast<T>(p.second + (read_cfrung << cfrung));
+                        abits += p.first;
+                        acc >>= p.first;
+                    }
+                    else { // use old cf
+                        acc >>= 1;
+                        abits++;
+                        cfrung = topbit(cf | 1);
+                    }
+                    // Have cf and cfrung
+                    s.advance(abits);
+                    acc = s.peek();
+                    if (rung | cfrung) {
+                        if (rung > 0)
                             failed |= !gdecode(s, rung, group, acc, 0);
-                        }
-                        else { // Decode here, it is missing the all-zeros flag
+                        else { // decode group here, it is missing the all-zero flag
                             for (int i = 0; i < B2; i++, acc >>= 1)
                                 group[i] = acc & 1;
                             s.advance(B2);
                         }
-                        // Multiply by CF and get the max for the actual rung
-                        T maxval = magsmul(group[0], cf);
-                        group[0] = maxval;
+                        // Multiply group by CF and get the max for the actual rung
+                        cf += 2;
+                        T maxval(group[0] = magsmul(group[0], cf));
                         for (int i = 1; i < B2; i++) {
                             auto val = magsmul(group[i], cf);
                             if (maxval < val) maxval = val;
                             group[i] = val;
                         }
-                        failed |= 2 > maxval; // CF has to be at least 2
+                        failed |= cf > maxval;
                         runbits[c] = topbit(maxval);
+                        cf -= 2; // Stored biased down
                     }
                     else { // rung == cfrung == 0, decode here, single bit for data
-                        runbits[c] = 1ull + (acc & 1);
-                        T val((0b10 << (acc & 1)) + 1); // -2 or -3, premultiplied
-                        for (int i = 0; i < B2; i++) {
-                            acc >>= 1;
+                        runbits[c] = 1ull + cf; // rung
+                        T val((0b10 << cf) + 1); // -2 or -3 in mags, premultiplied
+                        for (int i = 0; i < B2; i++, acc >>= 1)
                             group[i] = (acc & 1) ? val : 0;
-                        }
-                        s.advance(abits + B2 + 1);
+                        s.advance(B2);
                     }
+                    pcf[c] = cf;
                 }
                 // Undo the delta encoding for this block
                 auto prv = prev[c];

--- a/QB3lib/QB3decode.h
+++ b/QB3lib/QB3decode.h
@@ -308,7 +308,7 @@ static T magsmul(T val, T cf) {
 // reports most but not all errors, for example if the input stream is too short for the last block
 template<typename T>
 static bool decode(uint8_t *src, size_t len, T* image, 
-    size_t xsize, size_t ysize, size_t bands, size_t *cband)
+    size_t xsize, size_t ysize, size_t bands, uint8_t *cband)
 {
     static_assert(std::is_integral<T>() && std::is_unsigned<T>(), "Only unsigned integer types allowed");
     // Best block traversal order in most cases
@@ -363,7 +363,7 @@ static bool decode(uint8_t *src, size_t len, T* image,
                         cfrung = (rung + cs) & NORM_MASK;
                         failed |= (rung == cfrung);
                     }
-                    
+
                     if (rung | cfrung) { // 0 < cfrung < 63
                         if (sizeof(T) == 8 && (cfrung + abits) > 62) {
                             s.advance(abits);

--- a/QB3lib/QB3decode.h
+++ b/QB3lib/QB3decode.h
@@ -305,6 +305,7 @@ static T magsmul(T val, T cf) {
     return magsabs(val) * (cf << 1) - (val & 1);
 }
 
+// reports most but not all errors, for example if the input stream is too short for the last block
 template<typename T>
 static bool decode(uint8_t *src, size_t len, T* image, 
     size_t xsize, size_t ysize, size_t bands, size_t *cband)
@@ -333,6 +334,7 @@ static bool decode(uint8_t *src, size_t len, T* image,
             if (x + B > xsize)
                 x = xsize - B;
             for (int c = 0; c < bands; c++) {
+                failed |= s.empty(); // Stream can't be empty here
                 uint64_t cs(0), abits(1), acc(s.peek());
                 if (acc & 1) { // Rung change
                     cs = dsw[(acc >> 1) & LONG_MASK];
@@ -422,6 +424,7 @@ static bool decode(uint8_t *src, size_t len, T* image,
                 *dimg += *simg;
         }
     } // per block strip
-    return failed;
+    // It might not catch all errors
+    return failed || s.avail() > 7; 
 }
 } // namespace

--- a/QB3lib/QB3decode.h
+++ b/QB3lib/QB3decode.h
@@ -348,75 +348,66 @@ static bool decode(uint8_t *src, size_t len, T* image,
                     failed |= !gdecode(s, rung, group, acc, abits);
                     runbits[c] = rung;
                 }
-                else {
+                else { // CF encoding
                     cs = dsw[acc & LONG_MASK]; // rung, no flag
                     auto rung = (runbits[c] + cs) & NORM_MASK;
-                    failed |= (rung == NORM_MASK); // Not possible in CF encoding
+                    failed |= (rung == NORM_MASK); // Not allowed in CF encoding
                     auto cfrung(rung);
                     acc >>= (cs >> 12) - 1;
                     abits += (cs >> 12) - 1;
                     T cf = pcf[c];
-                    size_t read_cfrung(0);
-                    if (acc & 1) { // different cf
+                    auto read_cfr = acc & 1;
+                    abits++;
+                    acc >>= 1;
+                    if (read_cfr) { // different cf, need to read it
+                        read_cfr = acc & 1;
+                        abits++;
                         acc >>= 1;
-                        read_cfrung = acc & 1;
-                        abits += 2;
-                        acc >>= 1;
-                        if (0 != read_cfrung) {
+                        if (read_cfr) { // has own rung
                             cs = dsw[acc & LONG_MASK];
                             cfrung = (rung + cs) & NORM_MASK;
                             failed |= (cfrung == rung);
                             acc >>= (cs >> 12) - 1;
                             abits += (cs >> 12) - 1;
                         }
-                        if (sizeof(T) == 8 && (cfrung + abits) > 62) {
+                        if (sizeof(T) == 8 && (cfrung + abits) > 62) { // Rare
                             s.advance(abits);
                             acc = s.peek();
                             abits = 0;
                         }
-                        auto p = qb3dsztbl(acc, cfrung - read_cfrung);
-                        cf = static_cast<T>(p.second + (read_cfrung << cfrung));
+                        auto p = qb3dsztbl(acc, cfrung - read_cfr);
+                        pcf[c] = cf = static_cast<T>(p.second + (read_cfr << cfrung));
                         abits += p.first;
                         acc >>= p.first;
                     }
-                    else { // use old cf
-                        acc >>= 1;
-                        abits++;
-                        cfrung = topbit(cf | 1);
-                    }
-                    // Have cf and cfrung
-                    s.advance(abits);
-                    acc = s.peek();
-                    if (rung | cfrung) {
-                        if (rung > 0)
-                            failed |= !gdecode(s, rung, group, acc, 0);
-                        else { // decode group here, it is missing the all-zero flag
-                            for (int i = 0; i < B2; i++, acc >>= 1)
-                                group[i] = acc & 1;
-                            s.advance(B2);
-                        }
+                    cf += 2; // Use it unbiased
+                    if (rung) {
+                        s.advance(abits);
+                        failed |= !gdecode(s, rung, group, s.peek(), 0);
                         // Multiply group by CF and get the max for the actual rung
-                        cf += 2;
                         T maxval(group[0] = magsmul(group[0], cf));
                         for (int i = 1; i < B2; i++) {
                             auto val = magsmul(group[i], cf);
                             if (maxval < val) maxval = val;
                             group[i] = val;
                         }
-                        failed |= cf > maxval;
-                        runbits[c] = topbit(maxval);
-                        cf -= 2; // Stored biased down
+                        failed |= cf > maxval; // Can't be all zero
+                        runbits[c] = topbit(maxval|1);
                     }
-                    else { // rung == cfrung == 0, decode here, single bit for data
-                        runbits[c] = 1ull + cf; // rung
-                        T val((0b10 << cf) + 1); // -2 or -3 in mags, premultiplied
-                        for (int i = 0; i < B2; i++, acc >>= 1)
-                            group[i] = (acc & 1) ? val : 0;
-                        s.advance(B2);
+                    else { // Single bit for data, decode here
+                        if (abits + B2 > 64) {
+                            s.advance(abits);
+                            acc = s.peek();
+                            abits = 0;
+                        }
+                        T v[2] = { 0, magsmul(T(1), cf) };
+                        for (int i = 0; i < B2; i++)
+                            group[i] = v[(acc >> i) & 1];
+                        s.advance(B2 + abits);
+                        runbits[c] = topbit(v[1]);
                     }
-                    pcf[c] = cf;
                 }
-                // Undo the delta encoding for this block
+                // Undo delta encoding for this block
                 auto prv = prev[c];
                 T* const blockp = image + (y * xsize + x) * bands + c;
                 for (int i = 0; i < B2; i++)

--- a/QB3lib/QB3decode.h
+++ b/QB3lib/QB3decode.h
@@ -302,8 +302,8 @@ static bool gdecode(iBits &s, size_t rung, T * group, uint64_t acc, size_t abits
 // Absolute from mag-sign
 template<typename T> static T magsabs(T v) { return (v >> 1) + (v & 1); }
 
-// integer multiply val(in magsign) by cf(normal, positive)
-template<typename T> static T magsmul(T val, T cf) { return magsabs(val) * (cf << 1) - (val & 1); }
+// Multiply v(in magsign) by m(normal, positive)
+template<typename T> static T magsmul(T v, T m) { return magsabs(v) * (m << 1) - (v & 1); }
 
 // reports most but not all errors, for example if the input stream is too short for the last block
 template<typename T>
@@ -341,7 +341,6 @@ static bool decode(uint8_t *src, size_t len, T* image,
                     abits = cs >> 12;
                 }
                 acc >>= abits;
-
                 if (0 == cs || 0 != (cs & TBLMASK)) { // Normal decoding, not a signal
                     // abits is never > 8, so it's safe to call gdecode
                     auto rung = (runbits[c] + cs) & NORM_MASK;
@@ -417,7 +416,6 @@ static bool decode(uint8_t *src, size_t len, T* image,
             if (failed) break;
         } // per block
         if (failed) break;
-
         // For performance apply band delta per block stip, in linear order
         for (int c = 0; c < bands; c++) {
             if (c == cband[c]) continue;

--- a/QB3lib/QB3decode.h
+++ b/QB3lib/QB3decode.h
@@ -406,14 +406,14 @@ static bool decode(uint8_t *src, size_t len, T* image,
                             runbits[c] = topbit(v[1]);
                         }
                     }
-                    else { // IDX encoding goes here
+                    else { // IDX decoding
                         cs = dsw[acc & LONG_MASK]; // rung, no flag
                         rung = (runbits[c] + cs) & NORM_MASK;
                         runbits[c] = rung;
                         acc >>= (cs >> 12) - 1; // No flag
                         abits += (cs >> 12) - 1;
-                        failed |= rung == 63; // Not NORM_MASK, only 63, it gets avoided by encoder
-                        // Read the 16 index values in group, max is 7
+                        failed |= rung == 63; // TODO: Deal with 64bit overflow
+                        // 16 index values in group, max is 7
                         T maxval(0);
                         for (int i = 0; i < B2; i++) {
                             // Could use ddrg2
@@ -425,16 +425,15 @@ static bool decode(uint8_t *src, size_t len, T* image,
                             abits += v >> 12;
                         }
                         s.advance(abits);
-                        T values[B2] = {};
+                        T idxarray[B2 / 2] = {};
                         for (size_t i = 0; i <= maxval; i++) {
                             acc = s.peek();
                             auto v = qb3dsztbl(acc, rung);
-                            values[i] = T(v.second);
                             s.advance(v.first);
+                            idxarray[i] = T(v.second);
                         }
-                        // Map indices back to values
                         for (int i = 0; i < B2; i++)
-                            group[i] = values[group[i]];
+                            group[i] = idxarray[group[i]];
                     }
                 }
                 // Undo delta encoding for this block

--- a/QB3lib/QB3encode.cpp
+++ b/QB3lib/QB3encode.cpp
@@ -352,7 +352,7 @@ template<typename T> static int enc(const T *source, oBits &s, encsp p)
 {
     int error(0);
     if (p->quanta < 2) {
-        if (p->mode == qb3_mode::QB3M_BEST)
+        if (p->mode == qb3_mode::QB3M_CF)
             error = QB3::encode_best(source, s, *p);
         else
             error = QB3::encode_fast(source, s, *p);
@@ -373,7 +373,7 @@ template<typename T> static int enc(const T *source, oBits &s, encsp p)
     auto src = reinterpret_cast<const char*>(source);
 
 #define QENC(T) quantize(reinterpret_cast<T *>(buffer.data()), s, subimg);\
-                if (subimg.mode == qb3_mode::QB3M_BEST) \
+                if (subimg.mode == qb3_mode::QB3M_CF) \
                     error = QB3::encode_best(\
                         reinterpret_cast<std::make_unsigned<T>::type *>(buffer.data()), s, subimg);\
                 else\

--- a/QB3lib/QB3encode.cpp
+++ b/QB3lib/QB3encode.cpp
@@ -23,8 +23,10 @@ Contributors:  Lucian Plesea
 
 // constructor
 encsp qb3_create_encoder(size_t width, size_t height, size_t bands, qb3_dtype dt) {
-    if (width > 0x10000ul || height > 0x10000ul || bands == 0 
-        || bands > QB3_MAXBANDS || dt > int(QB3_I64))
+    if (width < 4 || width > 0x10000ul 
+        || height < 4 || height > 0x10000ul 
+        || bands == 0 || bands > QB3_MAXBANDS 
+        || dt > int(QB3_I64))
         return nullptr;
     auto p = new encs;
     p->xsize = width;
@@ -75,7 +77,7 @@ bool qb3_set_encoder_coreband(encsp p, size_t bands, size_t *cband) {
 bool qb3_set_encoder_quanta(encsp p, size_t q, bool away) {
     p->quanta = 1;
     p->away = false;
-    if (q < 1) // Quanta of zero if not valid
+    if (q < 1)
         return false;
     p->quanta = q;
     p->away = away;
@@ -84,7 +86,7 @@ bool qb3_set_encoder_quanta(encsp p, size_t q, bool away) {
     // Check the quanta value agains the max positive by type
     bool error = false;
     switch (p->type) {
-#define TOO_LARGE(Q, T) (Q > uint64_t(std::numeric_limits<int8_t>::max()))
+#define TOO_LARGE(Q, T) (Q > uint64_t(std::numeric_limits<T>::max()))
     case qb3_dtype::QB3_I8:
         error |= TOO_LARGE(p->quanta, int8_t);
     case qb3_dtype::QB3_U8:

--- a/QB3lib/QB3encode.cpp
+++ b/QB3lib/QB3encode.cpp
@@ -352,10 +352,10 @@ template<typename T> static int enc(const T *source, oBits &s, encsp p)
 {
     int error(0);
     if (p->quanta < 2) {
-        if (p->mode == qb3_mode::QB3M_CF)
-            error = QB3::encode_best(source, s, *p);
-        else
+        if (p->mode == qb3_mode::QB3M_DEFAULT)
             error = QB3::encode_fast(source, s, *p);
+        else
+            error = QB3::encode_best(source, s, *p);
         return error;
     }
 
@@ -373,11 +373,11 @@ template<typename T> static int enc(const T *source, oBits &s, encsp p)
     auto src = reinterpret_cast<const char*>(source);
 
 #define QENC(T) quantize(reinterpret_cast<T *>(buffer.data()), s, subimg);\
-                if (subimg.mode == qb3_mode::QB3M_CF) \
-                    error = QB3::encode_best(\
+                if (subimg.mode == qb3_mode::QB3M_DEFAULT) \
+                    error = QB3::encode_fast(\
                         reinterpret_cast<std::make_unsigned<T>::type *>(buffer.data()), s, subimg);\
                 else\
-                    error = QB3::encode_fast(\
+                    error = QB3::encode_best(\
                         reinterpret_cast<std::make_unsigned<T>::type *>(buffer.data()), s, subimg);
 
     for (size_t y = 0; y < ysz; y += subimg.ysize) {

--- a/QB3lib/QB3encode.cpp
+++ b/QB3lib/QB3encode.cpp
@@ -52,6 +52,16 @@ encsp qb3_create_encoder(size_t width, size_t height, size_t bands, qb3_dtype dt
     return p;
 }
 
+void qb3_reset_encoder(encsp p) {
+    for (size_t c = 0; c < p->nbands; c++) {
+        p->band[c].runbits = 0;
+        p->band[c].prev = 0;
+        p->band[c].cf = 0;
+        p->cband[c] = static_cast<uint8_t>(c);
+    }
+    p->error = 0;
+}
+
 void qb3_destroy_encoder(encsp p) {
     delete p;
 }

--- a/QB3lib/QB3encode.cpp
+++ b/QB3lib/QB3encode.cpp
@@ -1,4 +1,6 @@
 /*
+Content: C API QB3 encoding
+
 Copyright 2021-2023 Esri
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -9,8 +11,6 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-
-Content: C API QB3 encoding
 
 Contributors:  Lucian Plesea
 */

--- a/QB3lib/QB3encode.h
+++ b/QB3lib/QB3encode.h
@@ -423,11 +423,11 @@ static int ienc(const T grp[B2], size_t rung, size_t oldrung) {
         T val; // small unsigned int
     } KVP;
 
-    std::array<KVP, B2> v;
+    std::array<KVP, B2> v = {};
     size_t len = 0;
     // Add or increment the value
     for (int i = 0; i < B2; i++) {
-        int j = 0;
+        size_t j = 0;
         while (j < len && v[j].key != grp[i])
             j++;
         if (j == len)
@@ -561,8 +561,6 @@ static int encode_best(const T *image, oBits& s, encs &info)
                 }
 
                 auto cf = gcf(group);
-                int idx = ienc(group, rung, oldrung);
-
                 auto start = s.position();
                 if (cf < 2)
                     groupencode(group, maxval, oldrung, s);
@@ -571,8 +569,13 @@ static int encode_best(const T *image, oBits& s, encs &info)
                     pcf[c] = cf - 2; // Bias
                 }
                 start = s.position() - start;
-                if (idx < start)
-                    delta += start - idx;
+                // Check if it's even worth trying the index encoding
+                // That is the minimum size of a group with 2 discrete values
+                if (start >= (36 + 3 * UBITS + 2 * rung)) {
+                    int idx = ienc(group, rung, oldrung);
+                    if (idx < start)
+                        delta += start - idx;
+                }
             }
         }
     }

--- a/QB3lib/QB3encode.h
+++ b/QB3lib/QB3encode.h
@@ -80,7 +80,6 @@ static const uint16_t csw6[] = { 0x1000, 0x6001, 0x6009, 0x6011, 0x6019, 0x6021,
 0x80b7, 0x80c7, 0x80d7, 0x80e7, 0x80ff, 0x80ef, 0x80df, 0x80cf, 0x80bf, 0x80af, 0x809f, 0x808f, 0x807f, 0x806f, 0x805f, 0x804f,
 0x803f, 0x802f, 0x801f, 0x800f, 0x707b, 0x706b, 0x705b, 0x704b, 0x703b, 0x702b, 0x701b, 0x700b, 0x603d, 0x6035, 0x602d, 0x6025,
 0x601d, 0x6015, 0x600d, 0x6005 };
-static const uint16_t* CSW[] = { nullptr, nullptr, nullptr, csw3, csw4, csw5, csw6 };
 
 // integer divide val(in magsign) by cf(normal)
 template<typename T> static T magsdiv(T val, T cf) {return ((magsabs(val) / cf) << 1) - (val & 1);}
@@ -238,11 +237,15 @@ static void groupencode(T group[B2], T maxval, oBits& s,
     }
 }
 
+template<typename T> constexpr uint16_t SIGNAL = sizeof(T) == 1 ? 0x5017 : sizeof(T) == 2 ? 0x6037 : sizeof(T) == 4 ? 0x7077 : 0x80f7;
+template<typename T> constexpr size_t UBITS = sizeof(T) == 1 ? 3 : sizeof(T) == 2 ? 4 : sizeof(T) == 4 ? 5 : 6;
+template<typename T> constexpr uint64_t UBMASK = (1ull << UBITS<T>) - 1;
+template<typename T> uint16_t const *CSW = sizeof(T) == 1 ? csw3 : sizeof(T) == 2 ? csw4 : sizeof(T) == 4 ? csw5 : csw6;
+
 // Base QB3 group encode with code switch, returns encoded size
 template <typename T = uint8_t> 
 static void groupencode(T group[B2], T maxval, size_t oldrung, oBits& s) {
-    constexpr size_t UBITS = sizeof(T) == 1 ? 3 : sizeof(T) == 2 ? 4 : sizeof(T) == 4 ? 5 : 6;
-    uint64_t acc = CSW[UBITS][(topbit(maxval | 1) - oldrung) & ((1ull << UBITS) - 1)];
+    uint64_t acc = CSW<T>[(topbit(maxval | 1) - oldrung) & UBMASK<T>];
     groupencode(group, maxval, s, acc & TBLMASK, static_cast<size_t>(acc >> 12));
 }
 
@@ -250,10 +253,8 @@ static void groupencode(T group[B2], T maxval, size_t oldrung, oBits& s) {
 template <typename T = uint8_t>
 static void cfgenc(oBits &bits, T group[B2], T cf, size_t oldrung) {
     // Signal as switch to same rung, max-positive value, by UBITS
-    const uint16_t SIGNAL[] = { 0x0, 0x0, 0x0, 0x5017, 0x6037, 0x7077, 0x80f7 };
-    constexpr size_t UBITS = sizeof(T) == 1 ? 3 : sizeof(T) == 2 ? 4 : sizeof(T) == 4 ? 5 : 6;
-    uint64_t acc = SIGNAL[UBITS] & TBLMASK;
-    size_t abits = UBITS + 2; // SIGNAL[UBITS] >> 12;
+    uint64_t acc = SIGNAL<T> & TBLMASK;
+    size_t abits = SIGNAL<T> >> 12;
     // divide group values by CF and find the new maxvalue
     T maxval = 0;
     for (size_t i = 0; i < B2; i++) if (group[i])
@@ -263,11 +264,11 @@ static void cfgenc(oBits &bits, T group[B2], T cf, size_t oldrung) {
     auto cfrung = topbit(cf | 1); // rung for cf-2 value
     // Encode the trung, with or without switch
     // Use the wrong way switch for in-band
-    auto cs = CSW[UBITS][(trung - oldrung) & ((1ull << UBITS) - 1)];
+    auto cs = CSW<T>[(trung - oldrung) & UBMASK<T>];
     if ((cs >> 12) == 1) // Would be no-switch, use signal instead, it decodes to delta of zero
-        cs = SIGNAL[UBITS];
+        cs = SIGNAL<T>;
     // When trung is only somewhat larger than cfrung encode cf at same rung as data
-    if (trung >= cfrung && (trung < (cfrung + UBITS) || 0 == cfrung)) {
+    if (trung >= cfrung && (trung < (cfrung + UBITS<T>) || 0 == cfrung)) {
         acc |= (cs & TBLMASK) << abits;
         abits += cs >> 12;
         if (trung == 0) { // Special encoding for single bit
@@ -293,7 +294,7 @@ static void cfgenc(oBits &bits, T group[B2], T cf, size_t oldrung) {
         // Then encode cfrung, using code-switch from trung, 
         // skip the change bit, since rung will always be different
         // cfrung - trung is never 0
-        cs = CSW[UBITS][(cfrung - trung) & ((1ull << UBITS) - 1)];
+        cs = CSW<T>[(cfrung - trung) & UBMASK<T>];
         acc |= (cs & (TBLMASK - 1)) << (abits - 1);
         abits += static_cast<size_t>(cs >> 12) - 1;
         if (cfrung > 1) {
@@ -335,14 +336,15 @@ static T rfr0div(T x, T y) {
     return r + (!(x < 0) & (m >= y)) - ((x < 0) & ((m + y) <= 0));
 }
 
+// Best block traversal order in most cases
+static const uint8_t xlut[16] = { 0, 1, 0, 1, 2, 3, 2, 3, 0, 1, 0, 1, 2, 3, 2, 3 };
+static const uint8_t ylut[16] = { 0, 0, 1, 1, 0, 0, 1, 1, 2, 2, 3, 3, 2, 2, 3, 3 };
+
 // Only basic encoding
 template<typename T>
 static int encode_fast(const T* image, oBits& s, encs &info)
 {
     static_assert(std::is_integral<T>() && std::is_unsigned<T>(), "Only unsigned integer types allowed");
-    // Best block traversal order in most cases
-    const uint8_t xlut[16] = { 0, 1, 0, 1, 2, 3, 2, 3, 0, 1, 0, 1, 2, 3, 2, 3 };
-    const uint8_t ylut[16] = { 0, 0, 1, 1, 0, 0, 1, 1, 2, 2, 3, 3, 2, 2, 3, 3 };
     const size_t xsize(info.xsize), ysize(info.ysize), bands(info.nbands), * cband(info.cband);
     if (xsize == 0 || xsize > 0x10000ull || ysize == 0 || ysize > 0x10000ull || 0 == bands)
         return 1;
@@ -350,10 +352,10 @@ static int encode_fast(const T* image, oBits& s, encs &info)
     for (size_t c = 0; c < bands; c++)
         if (cband[c] >= bands)
             return 2; // Band mapping error
-    // Running code length, start with nominal value
-    size_t runbits[QB3_MAXBANDS] = {};
+    // Running code length
+    size_t runbits[QB3_MAXBANDS];
     // Previous value, per band
-    T prev[QB3_MAXBANDS] = {};
+    T prev[QB3_MAXBANDS];
     // Initialize state
     for (size_t c = 0; c < bands; c++) {
         runbits[c] = info.runbits[c];
@@ -413,9 +415,6 @@ template <typename T = uint8_t>
 static int encode_best(const T *image, oBits& s, encs &info)
 {
     static_assert(std::is_integral<T>() && std::is_unsigned<T>(), "Only unsigned integer types allowed");
-    // Best block traversal order in most cases
-    const uint8_t xlut[16] = { 0, 1, 0, 1, 2, 3, 2, 3, 0, 1, 0, 1, 2, 3, 2, 3 };
-    const uint8_t ylut[16] = { 0, 0, 1, 1, 0, 0, 1, 1, 2, 2, 3, 3, 2, 2, 3, 3 };
     const size_t xsize(info.xsize), ysize(info.ysize), bands(info.nbands), * cband(info.cband);
     if (xsize == 0 || xsize > 0x10000ull || ysize == 0 || ysize > 0x10000ull || 0 == bands)
         return 1;
@@ -423,7 +422,6 @@ static int encode_best(const T *image, oBits& s, encs &info)
     for (size_t c = 0; c < bands; c++)
         if (cband[c] >= bands)
             return 2; // Band mapping error
-    constexpr size_t UBITS = sizeof(T) == 1 ? 3 : sizeof(T) == 2 ? 4 : sizeof(T) == 4 ? 5 : 6;
     // Running code length, start with nominal value
     size_t runbits[QB3_MAXBANDS];
     // Previous value, per band
@@ -470,7 +468,7 @@ static int encode_best(const T *image, oBits& s, encs &info)
                 const size_t rung = topbit(maxval | 1);
                 runbits[c] = rung;
                 if (0 == rung) { // only 1s and 0s, rung is -1 or 0, no point in trying cf
-                    uint64_t acc = CSW[UBITS][(rung - oldrung) & ((1ull << UBITS) - 1)];
+                    uint64_t acc = CSW<T>[(rung - oldrung) & UBMASK<T>];
                     size_t abits = acc >> 12;
                     acc &= 0xffull;
                     acc |= static_cast<uint64_t>(maxval) << abits++; // Add the all-zero flag

--- a/QB3lib/bitstream.h
+++ b/QB3lib/bitstream.h
@@ -95,6 +95,7 @@ public:
         bitp += nbits;
     }
 
+    // Number of bits written
     size_t position() const {
         return bitp;
     }

--- a/QB3lib/bitstream.h
+++ b/QB3lib/bitstream.h
@@ -79,6 +79,7 @@ private:
 class oBits {
 public:
     oBits(uint8_t * data) : v(data), bitp(0) {}
+    void reset() { bitp = 0; } // Same buffer
 
     // Do not call with val having bits above "nbits" set, the results will be corrupt
     template<typename T>

--- a/QB3lib/bitstream.h
+++ b/QB3lib/bitstream.h
@@ -20,6 +20,7 @@ Contributors:  Lucian Plesea
 #include <cassert>
 #include <type_traits>
 #include <limits>
+#include <utility>
 
 // Input bitstream, doesn't go past size
 class iBits {
@@ -93,6 +94,11 @@ public:
         for (; nbits > used; used += 8)
             v[(bitp + used) / 8] = static_cast<uint8_t>(val >> used);
         bitp += nbits;
+    }
+
+    template<typename T>
+    void push(std::pair<size_t, T> p) {
+        push(p.second, p.first);
     }
 
     // Number of bits written

--- a/QB3lib/bitstream.h
+++ b/QB3lib/bitstream.h
@@ -79,7 +79,8 @@ private:
 class oBits {
 public:
     oBits(uint8_t * data) : v(data), bitp(0) {}
-    // Rewind to a bit position under the current one
+
+    // Rewind to a bit position before the current one
     size_t rewind(size_t pos = 0) {
         // Don't go past the current end
         if (pos < position()) {
@@ -115,7 +116,7 @@ public:
         for(auto pv = reinterpret_cast<uint64_t *>(other.v); len >=64; len-=64, pv++)
             push(*pv, 64);
         // Bytes at the end
-        for(auto pv = other.v + other.bitp / 8 ; len >= 8; len-=8, pv++)
+        for(auto pv = other.v + (other.bitp / 64) * 8 ; len >= 8; len-=8, pv++)
             push(*pv, 8);
         // Bits at the end
         if (len)

--- a/QB3lib/bitstream.h
+++ b/QB3lib/bitstream.h
@@ -79,7 +79,16 @@ private:
 class oBits {
 public:
     oBits(uint8_t * data) : v(data), bitp(0) {}
-    void reset() { bitp = 0; } // Same buffer
+    // Rewind to a bit position under the current one
+    size_t rewind(size_t pos = 0) {
+        // Don't go past the current end
+        if (pos < position()) {
+            bitp = pos;
+            if (bitp & 7) // clear partial bits in the last byte
+                v[bitp / 8] &= 0xff >> (8 - (bitp & 7));
+        }
+        return position();
+    }
 
     // Do not call with val having bits above "nbits" set, the results will be corrupt
     template<typename T>
@@ -98,8 +107,7 @@ public:
     }
 
     // Append content from other output bitstream
-    template<class T>
-    oBits& operator<<(const oBits&other) {
+    oBits& operator+=(const oBits&other) {
         iBits is(other.v, (other.bitp + 7) / 8);
 
         auto len = other.bitp;

--- a/QB3lib/bitstream.h
+++ b/QB3lib/bitstream.h
@@ -109,18 +109,17 @@ public:
 
     // Append content from other output bitstream
     oBits& operator+=(const oBits&other) {
-        iBits is(other.v, (other.bitp + 7) / 8);
-
         auto len = other.bitp;
-        // Whole 64bit words
-        for(auto pv = reinterpret_cast<uint64_t *>(other.v); len >=64; len-=64, pv++)
+        for(auto pv = reinterpret_cast<uint64_t *>(other.v); len >= 64; len -= 64, pv++)
             push(*pv, 64);
-        // Bytes at the end
-        for(auto pv = other.v + (other.bitp / 64) * 8 ; len >= 8; len-=8, pv++)
-            push(*pv, 8);
-        // Bits at the end
-        if (len)
-            push(*(other.v + other.bitp / 8), len);
+        // bits at the end
+        if (len) {
+            uint64_t acc = 0;
+            auto pv = other.v + (other.bitp / 64) * 8;
+            for (size_t i = 0; i * 8 < len; i++)
+                acc |= static_cast<uint64_t>(pv[i]) << (i * 8);
+            push(acc, len);
+        }
         return *this;
     }
 

--- a/QB3lib/bitstream.h
+++ b/QB3lib/bitstream.h
@@ -96,6 +96,24 @@ public:
         bitp += nbits;
     }
 
+    // Append content from other output bitstream
+    template<class T>
+    oBits& operator<<(const oBits&other) {
+        iBits is(other.v, (other.bitp + 7) / 8);
+
+        auto len = other.bitp;
+        // Whole 64bit words
+        for(auto pv = reinterpret_cast<uint64_t *>(other.v); len >=64; len-=64, pv++)
+            push(*pv, 64);
+        // Bytes at the end
+        for(auto pv = other.v + other.bitp / 8 ; len >= 8; len-=8, pv++)
+            push(*pv, 8);
+        // Bits at the end
+        if (len)
+            push(*(other.v + other.bitp / 8), len);
+        return *this;
+    }
+
     template<typename T>
     void push(std::pair<size_t, T> p) {
         push(p.second, p.first);

--- a/cqb3.cpp
+++ b/cqb3.cpp
@@ -1,6 +1,5 @@
 /*
-
-Basic QB3 image encode and decode, uses libicd for input
+Content: QB3 image encode and decode utility
 
 Copyright 2023 Esri
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -179,9 +178,6 @@ bool parse_args(int argc, char** argv, options& opt) {
             opt.error = "Invalid option for QB3 decoding\n";
             return Usage(opt);
         }
-    }
-    else {
-
     }
     return true;
 }

--- a/cqb3.cpp
+++ b/cqb3.cpp
@@ -474,6 +474,10 @@ int encode_main(options& opts) {
         return 2;
     }
 
+    // Warnings
+    if (strlen(params.error_message))
+        cerr << fname << " " << params.error_message << endl;
+
     if (opts.verbose)
         cerr << "Decode time: " << time_span << "s\nRatio " << fsize * 100.0 / image.size() << "%, rate: "
         << image.size() / time_span / 1024 / 1024 << " MB/s\n\n";

--- a/cqb3.cpp
+++ b/cqb3.cpp
@@ -17,6 +17,7 @@ Contributors:  Lucian Plesea
 
 #include <cstdint>
 #include <cstdlib>
+#include <cstring>
 #include <iostream>
 #include <sstream>
 #include <chrono>

--- a/test_qb3.cpp
+++ b/test_qb3.cpp
@@ -340,27 +340,28 @@ int main(int argc, char **argv)
 
             //check<uint8_t>(image, raster, 1, 1, false, 10);
             //cout << endl;
+            if (0) {
+                check<uint64_t>(image, raster, 5, 1);
+                cout << endl;
+                check<uint64_t>(image, raster, (1ull << 56), 1);
+                cout << endl;
+                check<uint32_t>(image, raster, 5, 1);
+                cout << endl;
+                check<uint32_t>(image, raster, 1ull << 24, 1);
+                cout << endl;
+                check<uint16_t>(image, raster, 5, 1);
+                cout << endl;
+                check<uint16_t>(image, raster, 1ull << 8, 1);
+                cout << endl;
 
-            check<uint64_t>(image, raster, 5, 1);
-            cout << endl;
-            check<uint64_t>(image, raster, (1ull << 56), 1);
-            cout << endl;
-            check<uint32_t>(image, raster, 5, 1);
-            cout << endl;
-            check<uint32_t>(image, raster, 1ull << 24, 1);
-            cout << endl;
-            check<uint16_t>(image, raster, 5, 1);
-            cout << endl;
-            check<uint16_t>(image, raster, 1ull << 8, 1);
-            cout << endl;
-
-            cout << "\nLarge rung\n";
-            check<uint64_t>(image, raster, (1ull << 56), 1, true);
-            cout << endl;
-            check<uint32_t>(image, raster, 1ull << 24, 1, true);
-            cout << endl;
-            check<uint16_t>(image, raster, 1ull << 8, 1, true);
-            cout << endl;
+                cout << "\nLarge rung\n";
+                check<uint64_t>(image, raster, (1ull << 56), 1, true);
+                cout << endl;
+                check<uint32_t>(image, raster, 1ull << 24, 1, true);
+                cout << endl;
+                check<uint16_t>(image, raster, 1ull << 8, 1, true);
+                cout << endl;
+            }
 
             cout << "\nData type\n";
             check<uint64_t>(image, raster, 1, 1);

--- a/test_qb3.cpp
+++ b/test_qb3.cpp
@@ -140,7 +140,7 @@ void check(vector<uint8_t> &image, const Raster &raster,
             auto y = re[i];
             if (!((x == y) || ((x > y) && (y + hq >= x)) || ((y > x) && (x + hq >= y)))) {
                 cout << endl << "Difference at " << i << " expect "
-                    << uint64_t(img[i]) << " != " << uint64_t(re[i]);
+                    << hex << uint64_t(img[i]) << " != " << uint64_t(re[i]) << dec;
                 cout << endl << "y = " << i / (xsize * bands) <<
                     " x = " << (i / bands) % xsize <<
                     " c = " << i % bands;
@@ -152,7 +152,7 @@ void check(vector<uint8_t> &image, const Raster &raster,
         for (size_t i = 0; i < img.size(); i++)
             if (img[i] != re[i]) {
                 cout << endl << "Difference at " << i << " expect "
-                    << img[i] << " got " << re[i];
+                    << hex << uint64_t(img[i]) << " got " << uint64_t(re[i]) << dec;
                 cout << endl << "y = " << i / (xsize * bands) <<
                     " x = " << (i / bands) % xsize <<
                     " c = " << i % bands;

--- a/test_qb3.cpp
+++ b/test_qb3.cpp
@@ -340,28 +340,27 @@ int main(int argc, char **argv)
 
             //check<uint8_t>(image, raster, 1, 1, false, 10);
             //cout << endl;
-            if (0) {
-                check<uint64_t>(image, raster, 5, 1);
-                cout << endl;
-                check<uint64_t>(image, raster, (1ull << 56), 1);
-                cout << endl;
-                check<uint32_t>(image, raster, 5, 1);
-                cout << endl;
-                check<uint32_t>(image, raster, 1ull << 24, 1);
-                cout << endl;
-                check<uint16_t>(image, raster, 5, 1);
-                cout << endl;
-                check<uint16_t>(image, raster, 1ull << 8, 1);
-                cout << endl;
 
-                cout << "\nLarge rung\n";
-                check<uint64_t>(image, raster, (1ull << 56), 1, true);
-                cout << endl;
-                check<uint32_t>(image, raster, 1ull << 24, 1, true);
-                cout << endl;
-                check<uint16_t>(image, raster, 1ull << 8, 1, true);
-                cout << endl;
-            }
+            check<uint64_t>(image, raster, 5, 1);
+            cout << endl;
+            check<uint64_t>(image, raster, (1ull << 56), 1);
+            cout << endl;
+            check<uint32_t>(image, raster, 5, 1);
+            cout << endl;
+            check<uint32_t>(image, raster, 1ull << 24, 1);
+            cout << endl;
+            check<uint16_t>(image, raster, 5, 1);
+            cout << endl;
+            check<uint16_t>(image, raster, 1ull << 8, 1);
+            cout << endl;
+
+            cout << "\nLarge rung\n";
+            check<uint64_t>(image, raster, (1ull << 56), 1, true);
+            cout << endl;
+            check<uint32_t>(image, raster, 1ull << 24, 1, true);
+            cout << endl;
+            check<uint16_t>(image, raster, 1ull << 8, 1, true);
+            cout << endl;
 
             cout << "\nData type\n";
             check<uint64_t>(image, raster, 1, 1);

--- a/test_qb3.cpp
+++ b/test_qb3.cpp
@@ -139,7 +139,7 @@ void check(vector<uint8_t> &image, const Raster &raster,
             auto x = img[i];
             auto y = re[i];
             if (!((x == y) || ((x > y) && (y + hq >= x)) || ((y > x) && (x + hq >= y)))) {
-                cout << endl << "Difference at " << i << " "
+                cout << endl << "Difference at " << i << " expect "
                     << uint64_t(img[i]) << " != " << uint64_t(re[i]);
                 cout << endl << "y = " << i / (xsize * bands) <<
                     " x = " << (i / bands) % xsize <<
@@ -151,8 +151,8 @@ void check(vector<uint8_t> &image, const Raster &raster,
     else {
         for (size_t i = 0; i < img.size(); i++)
             if (img[i] != re[i]) {
-                cout << endl << "Difference at " << i << " "
-                    << img[i] << " " << re[i];
+                cout << endl << "Difference at " << i << " expect "
+                    << img[i] << " got " << re[i];
                 cout << endl << "y = " << i / (xsize * bands) <<
                     " x = " << (i / bands) % xsize <<
                     " c = " << i % bands;
@@ -186,7 +186,7 @@ void check(vector<uint16_t>& image, const Raster& raster, uint64_t m, int main_b
 
     std::vector<T> re(xsize * ysize * bands);
 
-    size_t image_size[3]; // Space for output values
+    size_t image_size[3] = {}; // Space for output values
     auto failed = false;
     auto expected_size = xsize * ysize * bands * 2; // 16bit data
     size_t actual_size(0);
@@ -216,16 +216,15 @@ void check(vector<uint16_t>& image, const Raster& raster, uint64_t m, int main_b
     if (fast)
         cout << "Fast";
 
-    if (img != re) {
-        for (size_t i = 0; i < img.size(); i++)
-            if (img[i] != re[i]) {
-                cout << endl << "Difference at " << i << " "
-                    << img[i] << " " << re[i];
-                cout << endl << "y = " << i / (xsize * bands) <<
-                    " x = " << (i / bands) % xsize <<
-                    " c = " << i % bands;
-                break;
-            }
+    if (img == re)
+        return;
+    for (size_t i = 0; i < img.size(); i++) if (img[i] != re[i]) {
+        cout << endl << "Difference at " << i << " "
+            << img[i] << " " << re[i];
+        cout << endl << "y = " << i / (xsize * bands) <<
+            " x = " << (i / bands) % xsize <<
+            " c = " << i % bands;
+        break;
     }
 }
 

--- a/test_qb3.cpp
+++ b/test_qb3.cpp
@@ -341,43 +341,44 @@ int main(int argc, char **argv)
             //check<uint8_t>(image, raster, 1, 1, false, 10);
             //cout << endl;
 
-            check<uint64_t>(image, raster, 5, 1);
-            cout << endl;
-            check<uint64_t>(image, raster, (1ull << 56), 1);
-            cout << endl;
-            check<uint32_t>(image, raster, 5, 1);
-            cout << endl;
-            check<uint32_t>(image, raster, 1ull << 24, 1);
-            cout << endl;
-            check<uint16_t>(image, raster, 5, 1);
-            cout << endl;
-            check<uint16_t>(image, raster, 1ull << 8, 1);
-            cout << endl;
+            if (0) {
+                check<uint64_t>(image, raster, 5, 1);
+                cout << endl;
+                check<uint64_t>(image, raster, (1ull << 56), 1);
+                cout << endl;
+                check<uint32_t>(image, raster, 5, 1);
+                cout << endl;
+                check<uint32_t>(image, raster, 1ull << 24, 1);
+                cout << endl;
+                check<uint16_t>(image, raster, 5, 1);
+                cout << endl;
+                check<uint16_t>(image, raster, 1ull << 8, 1);
+                cout << endl;
 
-            cout << "\nLarge rung\n";
-            check<uint64_t>(image, raster, (1ull << 56), 1, true);
-            cout << endl;
-            check<uint32_t>(image, raster, 1ull << 24, 1, true);
-            cout << endl;
-            check<uint16_t>(image, raster, 1ull << 8, 1, true);
-            cout << endl;
+                cout << "\nLarge rung\n";
+                check<uint64_t>(image, raster, (1ull << 56), 1, true);
+                cout << endl;
+                check<uint32_t>(image, raster, 1ull << 24, 1, true);
+                cout << endl;
+                check<uint16_t>(image, raster, 1ull << 8, 1, true);
+                cout << endl;
 
-            cout << "\nData type\n";
-            check<uint64_t>(image, raster, 1, 1);
-            cout << endl;
-            check<uint64_t>(image, raster, 1, 1, true);
-            cout << endl;
+                cout << "\nData type\n";
+                check<uint64_t>(image, raster, 1, 1);
+                cout << endl;
+                check<uint64_t>(image, raster, 1, 1, true);
+                cout << endl;
 
-            check<uint32_t>(image, raster, 1, 1);
-            cout << endl;
-            check<uint32_t>(image, raster, 1, 1, true);
-            cout << endl;
+                check<uint32_t>(image, raster, 1, 1);
+                cout << endl;
+                check<uint32_t>(image, raster, 1, 1, true);
+                cout << endl;
 
-            check<uint16_t>(image, raster, 1, 1);
-            cout << endl;
-            check<uint16_t>(image, raster, 1, 1, true);
-            cout << endl;
-
+                check<uint16_t>(image, raster, 1, 1);
+                cout << endl;
+                check<uint16_t>(image, raster, 1, 1, true);
+                cout << endl;
+            }
             check<uint8_t>(image, raster, 1, 1);
             cout << endl;
             check<uint8_t>(image, raster, 1, 1, true);

--- a/test_qb3.cpp
+++ b/test_qb3.cpp
@@ -341,44 +341,43 @@ int main(int argc, char **argv)
             //check<uint8_t>(image, raster, 1, 1, false, 10);
             //cout << endl;
 
-            if (0) {
-                check<uint64_t>(image, raster, 5, 1);
-                cout << endl;
-                check<uint64_t>(image, raster, (1ull << 56), 1);
-                cout << endl;
-                check<uint32_t>(image, raster, 5, 1);
-                cout << endl;
-                check<uint32_t>(image, raster, 1ull << 24, 1);
-                cout << endl;
-                check<uint16_t>(image, raster, 5, 1);
-                cout << endl;
-                check<uint16_t>(image, raster, 1ull << 8, 1);
-                cout << endl;
+            check<uint64_t>(image, raster, 5, 1);
+            cout << endl;
+            check<uint64_t>(image, raster, (1ull << 56), 1);
+            cout << endl;
+            check<uint32_t>(image, raster, 5, 1);
+            cout << endl;
+            check<uint32_t>(image, raster, 1ull << 24, 1);
+            cout << endl;
+            check<uint16_t>(image, raster, 5, 1);
+            cout << endl;
+            check<uint16_t>(image, raster, 1ull << 8, 1);
+            cout << endl;
 
-                cout << "\nLarge rung\n";
-                check<uint64_t>(image, raster, (1ull << 56), 1, true);
-                cout << endl;
-                check<uint32_t>(image, raster, 1ull << 24, 1, true);
-                cout << endl;
-                check<uint16_t>(image, raster, 1ull << 8, 1, true);
-                cout << endl;
+            cout << "\nLarge rung\n";
+            check<uint64_t>(image, raster, (1ull << 56), 1, true);
+            cout << endl;
+            check<uint32_t>(image, raster, 1ull << 24, 1, true);
+            cout << endl;
+            check<uint16_t>(image, raster, 1ull << 8, 1, true);
+            cout << endl;
 
-                cout << "\nData type\n";
-                check<uint64_t>(image, raster, 1, 1);
-                cout << endl;
-                check<uint64_t>(image, raster, 1, 1, true);
-                cout << endl;
+            cout << "\nData type\n";
+            check<uint64_t>(image, raster, 1, 1);
+            cout << endl;
+            check<uint64_t>(image, raster, 1, 1, true);
+            cout << endl;
 
-                check<uint32_t>(image, raster, 1, 1);
-                cout << endl;
-                check<uint32_t>(image, raster, 1, 1, true);
-                cout << endl;
+            check<uint32_t>(image, raster, 1, 1);
+            cout << endl;
+            check<uint32_t>(image, raster, 1, 1, true);
+            cout << endl;
 
-                check<uint16_t>(image, raster, 1, 1);
-                cout << endl;
-                check<uint16_t>(image, raster, 1, 1, true);
-                cout << endl;
-            }
+            check<uint16_t>(image, raster, 1, 1);
+            cout << endl;
+            check<uint16_t>(image, raster, 1, 1, true);
+            cout << endl;
+
             check<uint8_t>(image, raster, 1, 1);
             cout << endl;
             check<uint8_t>(image, raster, 1, 1, true);

--- a/test_qb3.cpp
+++ b/test_qb3.cpp
@@ -1,4 +1,6 @@
 /*
+Content: Debugging aid
+
 Copyright 2020-2023 Esri
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -93,7 +95,8 @@ void check(vector<uint8_t> &image, const Raster &raster,
     qenc = nullptr;
 
     cout << outsize << '\t' << outsize * 100.0 / image.size() / sizeof(T) 
-        << '\t' << image.size() * sizeof(T) / time_span / 1024 / 1024 << '\t' << time_span << '\t';
+        << '\t' << image.size() * sizeof(T) / time_span / 1024 / 1024 
+        << '\t' << time_span << '\t';
     if (err)
         cout << "\nFailed\n";
 
@@ -363,14 +366,20 @@ int main(int argc, char **argv)
             cout << "\nData type\n";
             check<uint64_t>(image, raster, 1, 1);
             cout << endl;
-            check<uint32_t>(image, raster, 1, 1);
-            cout << endl;
-            check<uint16_t>(image, raster, 1, 1);
-            cout << endl;
-            check<uint8_t>(image, raster, 1, 1);
+            check<uint64_t>(image, raster, 1, 1, true);
             cout << endl;
 
+            check<uint32_t>(image, raster, 1, 1);
+            cout << endl;
+            check<uint32_t>(image, raster, 1, 1, true);
+            cout << endl;
+
+            check<uint16_t>(image, raster, 1, 1);
+            cout << endl;
             check<uint16_t>(image, raster, 1, 1, true);
+            cout << endl;
+
+            check<uint8_t>(image, raster, 1, 1);
             cout << endl;
             check<uint8_t>(image, raster, 1, 1, true);
             cout << endl;

--- a/test_qb3.cpp
+++ b/test_qb3.cpp
@@ -304,8 +304,12 @@ int main(int argc, char **argv)
 
             std::vector<uint8_t> image(params.get_buffer_size());
             auto t = high_resolution_clock::now();
-            stride_decode(params, source, image.data());
+            auto err_message = stride_decode(params, source, image.data());
             auto time_span = duration_cast<duration<double>>(high_resolution_clock::now() - t).count();
+            if (err_message) {
+                cerr << err_message << endl;
+                return 1;
+            }
             cout << "Decode time " << time_span << " rate " << image.size() / time_span / 1024 / 1024 << " MB/s" << endl;
 
             cout << "Size\tRatio %\tEnc (MB/s)\t(s)\tDec (MB/s)\t(s)\tT_Size\n\n";
@@ -386,8 +390,13 @@ int main(int argc, char **argv)
         else if (raster.dt == ICDT_Int16 || raster.dt == ICDT_UInt16) {
             std::vector<uint16_t> image(params.get_buffer_size() / 2);
             auto t = high_resolution_clock::now();
-            stride_decode(params, source, image.data());
+            auto err_message = stride_decode(params, source, image.data());
             auto time_span = duration_cast<duration<double>>(high_resolution_clock::now() - t).count();
+            if (err_message) {
+                cerr << err_message << endl;
+                return 1;
+            }
+
             cout << "Decode time " << time_span << endl;
 
             cout << "Compressed\tRatio\tEncode\tDecode\tType\n\n";


### PR DESCRIPTION
Fast encoding is backwards compatible

- Add RLE0FFFF as a second pass, to improve compression of constant areas
- Smaller encoding of CF groups, using running CF values
- Add group index encoding
- Performance improvements
- cqb3 utility improvements
- Bug fixes