### PR TITLE
Fix build error on Ubuntu 24.04 / gcc 13.2.0

### DIFF
--- a/QB3lib/CMakeLists.txt
+++ b/QB3lib/CMakeLists.txt
@@ -20,9 +20,22 @@ option(BUILD_SHARED_LIBS "Library style" ON)
 set(namespace "QB3")
 add_library(${PROJECT_NAME})
 
-# On AMD64 uncomment to use avx2 -> faster code
-# target_compile_options(${PROJECT_NAME} PRIVATE $<$<CXX_COMPILER_ID:MSVC>:/arch:AVX2>)
-# target_compile_options(${PROJECT_NAME} PRIVATE $<$<CXX_COMPILER_ID:GNU>:-mavx2>)
+if("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "x86_64" AND ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU"))
+    option(ENABLE_SSE4 "Enable SSE4 optimizations" ON)
+    if (ENABLE_SSE4)
+        target_compile_options(${PROJECT_NAME} PRIVATE "-msse4")
+    endif()
+
+    option(ENABLE_AVX2 "Enable AVX2 optimizations" OFF)
+    if (ENABLE_AVX2)
+        target_compile_options(${PROJECT_NAME} PRIVATE "-mavx2")
+    endif()
+elseif("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "AMD64" AND MSVC)
+    option(ENABLE_AVX2 "Enable AVX2 optimizations" OFF)
+    if (ENABLE_AVX2)
+        target_compile_options(${PROJECT_NAME} PRIVATE "/arch:AVX2")
+    endif()
+endif()
 
 target_sources(${PROJECT_NAME} 
     PRIVATE QB3encode.cpp QB3encode.h QB3decode.cpp QB3decode.h QB3common.h bitstream.h QB3.h

--- a/QB3lib/QB3common.h
+++ b/QB3lib/QB3common.h
@@ -16,6 +16,7 @@ Contributors:  Lucian Plesea
 */
 
 #pragma once
+
 #include "QB3.h"
 #include "bitstream.h"
 #include <cinttypes>
@@ -32,11 +33,6 @@ constexpr auto TBLMASK(0xfffull);
 // Block is 4x4 pixels
 constexpr size_t B(4);
 constexpr size_t B2(B * B);
-
-#if defined(__GNUC__) && defined(__x86_64__)
-// Comment out if binary is to run on processors without sse4
-#pragma GCC target("sse4")
-#endif
 
 #if defined(_WIN32)
 // blog2 of val, result is undefined for val == 0


### PR DESCRIPTION
Fixes #16

gcc 13.2.0 is confused by the ``#pragma GCC target("sse4")`` in QB3Common.h.
Passing -msse4 as a compile option works better. While we are it introduce CMake variables ENABLE_SSE4 and ENABLE_AVX2 to control those optimization levels