### PR TITLE
Allow 32bit builds

### DIFF
--- a/QB3lib/QB3.h
+++ b/QB3lib/QB3.h
@@ -18,6 +18,7 @@ Contributors:  Lucian Plesea
 #pragma once
 // For size_t
 #include <stddef.h>
+#include <cstdint>
 
 // CMake will generate LIBQB3_EXPORT linkage as needed
 #include <libqb3_export.h>
@@ -87,7 +88,7 @@ LIBQB3_EXPORT bool qb3_set_encoder_coreband(encsp p, size_t bands, size_t *cband
 
 // Sets quantization parameters, returns true on success
 // away = true -> round away from zero
-LIBQB3_EXPORT bool qb3_set_encoder_quanta(encsp p, size_t q, bool away);
+LIBQB3_EXPORT bool qb3_set_encoder_quanta(encsp p, uint64_t q, bool away);
 
 // Upper bound of encoded size, without taking the header into consideration
 LIBQB3_EXPORT size_t qb3_max_encoded_size(const encsp p);
@@ -136,10 +137,10 @@ LIBQB3_EXPORT void qb3_set_decoder_stride(decsp p, size_t stride);
 LIBQB3_EXPORT qb3_mode qb3_get_mode(const decsp p);
 
 // Returns the number of quantization bits used, returns 0 if failed
-LIBQB3_EXPORT size_t qb3_get_quanta(const decsp p);
+LIBQB3_EXPORT uint64_t qb3_get_quanta(const decsp p);
 
 // Return the scanning curve used, returns 0 if failed
-LIBQB3_EXPORT size_t qb3_get_order(const decsp p);
+LIBQB3_EXPORT uint64_t qb3_get_order(const decsp p);
 
 // Sets the cband array and returns true if successful
 LIBQB3_EXPORT bool qb3_get_coreband(const decsp p, size_t *cband);

--- a/QB3lib/QB3common.h
+++ b/QB3lib/QB3common.h
@@ -34,14 +34,14 @@ constexpr auto TBLMASK(0xfffull);
 constexpr size_t B(4);
 constexpr size_t B2(B * B);
 
-#if defined(_WIN32)
+#if defined(_WIN32) && defined(_WIN64)
 // blog2 of val, result is undefined for val == 0
 static size_t topbit(uint64_t val) {
     return 63 - __lzcnt64(val);
 }
 
 static size_t setbits16(uint64_t val) {
-    return __popcnt64(val);
+    return __popcnt16(uint16_t(val));
 }
 
 #elif defined(__GNUC__)
@@ -86,7 +86,7 @@ struct encs {
     size_t nbands;
     // micro block scanning order
     uint64_t order;
-    size_t quanta;
+    uint64_t quanta;
 
     // Persistent state by band
     band_state band[QB3_MAXBANDS];
@@ -109,7 +109,7 @@ struct decs {
     size_t stride;
     // micro block scanning order
     uint64_t order;
-    size_t quanta;
+    uint64_t quanta;
     int error;
     int stage;
 

--- a/QB3lib/QB3decode.cpp
+++ b/QB3lib/QB3decode.cpp
@@ -48,13 +48,13 @@ qb3_mode qb3_get_mode(const decsp p) {
     return p->mode;
 }
 
-size_t qb3_get_quanta(const decsp p) {
+uint64_t qb3_get_quanta(const decsp p) {
     if (p->stage != 2)
         return 0; // Error
     return p->quanta;
 }
 
-size_t qb3_get_order(const decsp p) {
+uint64_t qb3_get_order(const decsp p) {
     if (p->stage != 2)
         return 0; // Error
     return p->order ? p->order : ZCURVE;
@@ -64,7 +64,7 @@ size_t qb3_get_order(const decsp p) {
 bool qb3_get_coreband(const decsp p, size_t *coreband) {
     if (p->stage != 2)
         return false; // Error
-    for (int c = 0; c < p->nbands; c++)
+    for (size_t c = 0; c < p->nbands; c++)
         coreband[c] = p->cband[c];
     return true;
 }
@@ -189,7 +189,7 @@ bool qb3_read_info(decsp p) {
         // size of chunk, if available
         uint16_t len = uint16_t(val & 0xffffu);
         if (check_sig(chunk, "QV")) { // Quanta
-            if (len > 4 || len < 1) {
+            if (len > 8 || len < 1) {
                 p->error = QB3E_EINV;
                 break;
             }

--- a/QB3lib/QB3encode.cpp
+++ b/QB3lib/QB3encode.cpp
@@ -87,7 +87,7 @@ bool qb3_set_encoder_coreband(encsp p, size_t bands, size_t *cband) {
 // Valid values are 2 and above
 // sign = true when the input data is signed
 // away = true to round away from zero
-bool qb3_set_encoder_quanta(encsp p, size_t q, bool away) {
+bool qb3_set_encoder_quanta(encsp p, uint64_t q, bool away) {
     p->quanta = 1;
     p->away = false;
     if (q < 1)
@@ -225,7 +225,7 @@ void static write_qb3_header(encsp p, oBits& s) {
 
 // Are there any band mappings
 bool static is_banddiff(encsp p) {
-    for (int c = 0; c < p->nbands; c++)
+    for (size_t c = 0; c < p->nbands; c++)
         if (p->cband[c] != c)
             return true;
     return false;
@@ -247,7 +247,7 @@ void static write_cband_header(encsp p, oBits& s) {
     push_sig("CB", s);
     s.push(p->nbands, 16); // size of payload
     // One byte per band, dump core band list
-    for (int i = 0; i < p->nbands; i++)
+    for (size_t i = 0; i < p->nbands; i++)
         s.push(p->cband[i], 8); // 8 bits each
 }
 


### PR DESCRIPTION
Specify uint64_t when 64bits are strictly necessary. size_t could be either 32bit or 64bit.