### PR TITLE
Fix build on i386

### DIFF
--- a/QB3lib/QB3encode.cpp
+++ b/QB3lib/QB3encode.cpp
@@ -84,7 +84,7 @@ void qb3_set_encoder_stride(encsp p, size_t stride) {
 // Valid values are 2 and above
 // sign = true when the input data is signed
 // away = true to round away from zero
-bool qb3_set_encoder_quanta(encsp p, size_t q, bool away) {
+bool qb3_set_encoder_quanta(encsp p, uint64_t q, bool away) {
     if (q < 1)
         return false;
     p->quanta = q;


### PR DESCRIPTION
It fixes the inconsistent definition.

from QB3lib/QB3.h:
LIBQB3_EXPORT bool qb3_set_encoder_quanta(encsp p, uint64_t q, bool away);

from QB3lib/QB3encode.cpp:
bool qb3_set_encoder_quanta(encsp p, size_t q, bool away) {

Tested on FreeBSD. The original [build failure](https://pkg-status.freebsd.org/beefy21/data/142i386-default/8b06c03ce600/logs/qb3-1.3.2.log) is fixed.